### PR TITLE
Add location support to posts

### DIFF
--- a/pwa-blog/backend/src/blog-comment/blog-comment.controller.ts
+++ b/pwa-blog/backend/src/blog-comment/blog-comment.controller.ts
@@ -30,12 +30,14 @@ export class BlogCommentController {
   }
 
   @Get('post/:id')
+  @ZodSerializerDto(BlogCommentResponseDto)
   getAllByPostId(@Param() params: IdDto) {
     return this.blogCommentService.getAllByPostId(params.id);
   }
 
   @Auth()
   @Get('user/:id')
+  @ZodSerializerDto(BlogCommentResponseDto)
   getAllByUserId(@Param() params: IdDto) {
     return this.blogCommentService.getAllByUserId(params.id);
   }

--- a/pwa-blog/backend/src/blog-post/blog-post.controller.ts
+++ b/pwa-blog/backend/src/blog-post/blog-post.controller.ts
@@ -13,6 +13,7 @@ import { Role } from '@pwa/shared';
 import { BlogPostService } from './blog-post.service';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { IdDto } from '../shared/dto/id.dto';
+import { LocationQuerySchema } from './dto/location.dto';
 import { CreateBlogPostDto } from './dto/create-blog-post.dto';
 import { UpdateBlogPostDto } from './dto/update-blog-post.dto';
 import { BlogPostResponseDto } from './dto/blog-post-response.dto';
@@ -23,8 +24,9 @@ export class BlogPostController {
 
   @Get()
   @ZodSerializerDto(BlogPostResponseDto)
-  getAll(@Query('search') search?: string) {
-    return this.blogPostService.getAll(search);
+  getAll(@Query('search') search?: string, @Query() locationQuery?: unknown) {
+    const { data: location } = LocationQuerySchema.safeParse(locationQuery);
+    return this.blogPostService.getAll(search, location);
   }
 
   @Get(':id')

--- a/pwa-blog/backend/src/blog-post/dto/location.dto.ts
+++ b/pwa-blog/backend/src/blog-post/dto/location.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { createZodDto } from 'nestjs-zod';
+
+export const LocationQuerySchema = z.object({
+  latitude: z.number({ coerce: true }),
+  longitude: z.number({ coerce: true }),
+  distance: z.number({ coerce: true }),
+});
+
+export class LocationQueryDto extends createZodDto(LocationQuerySchema) {}

--- a/pwa-blog/backend/src/blog-post/schemas/blog-post.schema.ts
+++ b/pwa-blog/backend/src/blog-post/schemas/blog-post.schema.ts
@@ -1,10 +1,11 @@
-import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Prop, raw, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, {
   ObjectId,
   Document,
   PopulatedDoc,
   HydratedDocument,
 } from 'mongoose';
+import { Location, LOCATION_TYPES_LIST } from '@pwa/shared';
 import { User } from '../../user/schemas/user.schema';
 
 export type BlogPostDocument = HydratedDocument<BlogPost>;
@@ -27,8 +28,17 @@ export class BlogPost {
   })
   author: PopulatedDoc<Document<ObjectId> & User>[];
 
+  @Prop(
+    raw({
+      type: { type: String, enum: LOCATION_TYPES_LIST },
+      coordinates: { type: [Number] },
+    }),
+  )
+  location?: Location | null;
+
   createdAt: Date;
   udpatedAt: Date;
 }
 
 export const BlogPostSchema = SchemaFactory.createForClass(BlogPost);
+BlogPostSchema.index({ location: '2dsphere' });

--- a/pwa-blog/shared/src/index.ts
+++ b/pwa-blog/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from './dto/blog-comment/blog-comment-response.dto';
 
 /* --------------------------------- Schemas -------------------------------- */
 export * from './schemas/user.schema';
+export * from './schemas/location.schema';
 export * from './schemas/blog-post.schema';
 export * from './schemas/blog-comment.schema';
 export * from './schemas/utils';

--- a/pwa-blog/shared/src/schemas/blog-post.schema.ts
+++ b/pwa-blog/shared/src/schemas/blog-post.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { UserSchema } from './user.schema';
+import { LocationSchema } from './location.schema';
 import { IdSchema, ReferenceSchema, TimestampSchema } from './utils';
 
 export const BlogPostSchema = z.object({
@@ -8,6 +9,15 @@ export const BlogPostSchema = z.object({
   description: z.string().optional(),
   body: z.string().min(1, 'Body is required'),
   author: ReferenceSchema(UserSchema),
+  location: z.preprocess((data) => {
+    if (
+      data && typeof data === 'object' &&
+      'toObject' in data && typeof data.toObject === 'function'
+    ) {
+      return data.toObject();
+    }
+    return data;
+  }, LocationSchema.nullish().default(null)),
   createdAt: TimestampSchema,
   updatedAt: TimestampSchema.optional(),
 });

--- a/pwa-blog/shared/src/schemas/location.schema.ts
+++ b/pwa-blog/shared/src/schemas/location.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const LOCATION_TYPES_LIST = ['Point'];
+
+export const LocationSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: z.tuple([z.number(), z.number()]),
+});
+
+export type Location = z.infer<typeof LocationSchema>;


### PR DESCRIPTION
# What's new

* Add geolocation support to support to Blog posts
* Update `GET /blog-posts` (get all) endpoint to support querying posts within a given distance from the provided coordinates
* Add missing DTO serializer to blog comment controller