### PR TITLE
Blog post scheduling

### DIFF
--- a/pwa-blog/backend/src/blog-post/blog-post.service.ts
+++ b/pwa-blog/backend/src/blog-post/blog-post.service.ts
@@ -52,8 +52,17 @@ export class BlogPostService {
 
     return this.blogPostModel
       .find({
-        ...searchQuery,
-        ...locationQuery,
+        $and: [
+          searchQuery,
+          locationQuery,
+          {
+            $or: [
+              { publishDate: null },
+              { publishDate: { $exists: false } },
+              { publishDate: { $lte: new Date() } },
+            ],
+          },
+        ],
       })
       .sort({ createdAt: 'desc' })
       .populate('author');

--- a/pwa-blog/backend/src/blog-post/schemas/blog-post.schema.ts
+++ b/pwa-blog/backend/src/blog-post/schemas/blog-post.schema.ts
@@ -38,6 +38,9 @@ export class BlogPost {
 
   createdAt: Date;
   udpatedAt: Date;
+
+  @Prop({ type: Date })
+  publishDate: Date | null;
 }
 
 export const BlogPostSchema = SchemaFactory.createForClass(BlogPost);

--- a/pwa-blog/backend/src/user/user.service.ts
+++ b/pwa-blog/backend/src/user/user.service.ts
@@ -48,6 +48,15 @@ export class UserService {
     user: UserDocument,
     updateUserProfileDto: UpdateUserProfileDto,
   ): Promise<UserDocument> {
+    if (
+      user.email !== updateUserProfileDto.email &&
+      !(await this.verifyAvailableEmail({ email: updateUserProfileDto.email }))
+    ) {
+      throw new ConflictException(
+        'User with the provided email already exists',
+      );
+    }
+
     user.set(updateUserProfileDto);
     return user.save();
   }

--- a/pwa-blog/shared/src/schemas/blog-post.schema.ts
+++ b/pwa-blog/shared/src/schemas/blog-post.schema.ts
@@ -21,6 +21,7 @@ export const BlogPostSchema = z.object({
   }, LocationSchema.nullish().default(null)),
   createdAt: TimestampSchema,
   updatedAt: TimestampSchema.optional(),
+  publishDate: TimestampSchema.nullish().default(null),
 });
 
 export type BlogPostType = z.infer<typeof BlogPostSchema>;


### PR DESCRIPTION
# What's changed

* Add `publishDate` property to `BlogPost` entity and schema.
* Update `getAll` blog posts query to return only post with a `publishDate` in the past, if a `publishDate` is set.
* Throw `ConflictException` on the `updateUserProfile` method if the updated email is already taken, instead of the error from mongoose, to make it clear what caused the error. 